### PR TITLE
build(release): replace go-semantic-release with local script + GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,6 @@ jobs:
       - name: mise run ci
         run: mise run ci
       - name: release
-        uses: go-semantic-release/action@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          allow-initial-development-versions: true
-          changelog-file: true
-          changelog-generator-opt: "emojis=true"
-          hooks: goreleaser
+        run: mise run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ go.work
 # mise local overrides (never commit). NOTE: mise.lock IS committed.
 mise.local.toml
 .mise.local.toml
+
+# GoReleaser build output
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 project_name: nothelp
 builds:
   - main: ./
@@ -13,5 +14,28 @@ builds:
       - -trimpath
       - -buildvcs=false
 archives:
-  - format: tar.gz
+  - formats: ["tar.gz"]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "^ci:"
+      - "^build:"
+      - "^style:"
+      - "^Merge "
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\(.+\))??!?:.+$'
+      order: 0
+    - title: Bug fixes
+      regexp: '^.*?fix(\(.+\))??!?:.+$'
+      order: 1
+    - title: Performance
+      regexp: '^.*?perf(\(.+\))??!?:.+$'
+      order: 2
+    - title: Others
+      order: 999

--- a/.mise/scripts/release.sh
+++ b/.mise/scripts/release.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Cut a release: compute the next version from Conventional Commits, tag it, and
+# publish binaries + release notes with GoReleaser.
+#
+# Versioning preserves the project's established cadence (and the previous
+# go-semantic-release `allow-initial-development-versions` behaviour):
+#   feat            -> minor
+#   fix / perf      -> patch
+#   breaking change -> minor while 0.x, major once >= 1.0
+# A push containing only chore/docs/ci/etc. commits cuts no release.
+#
+# Set RELEASE_DRY_RUN=1 to print the computed version and exit before tagging or
+# publishing. The publish step needs GITHUB_TOKEN.
+set -euo pipefail
+
+current="$(convco version)"
+range="v${current}..HEAD"
+
+subjects="$(git log --no-merges --format='%s' "${range}" || true)"
+bodies="$(git log --no-merges --format='%B' "${range}" || true)"
+
+bump=""
+if printf '%s\n' "${subjects}" | grep -qE '^[a-zA-Z]+(\([^)]*\))?!:' ||
+	printf '%s\n' "${bodies}" | grep -qE '^BREAKING[ -]CHANGE:'; then
+	bump="major"
+elif printf '%s\n' "${subjects}" | grep -qE '^feat(\([^)]*\))?:'; then
+	bump="minor"
+elif printf '%s\n' "${subjects}" | grep -qE '^(fix|perf)(\([^)]*\))?:'; then
+	bump="patch"
+fi
+
+if [ -z "${bump}" ]; then
+	echo "release: no feat/fix/perf/breaking commits since v${current}; nothing to release."
+	exit 0
+fi
+
+IFS='.' read -r major minor patch <<<"${current}"
+
+case "${bump}" in
+major)
+	if [ "${major}" -eq 0 ]; then
+		# Stay in 0.x, matching the old allow-initial-development-versions setting.
+		minor=$((minor + 1))
+		patch=0
+	else
+		major=$((major + 1))
+		minor=0
+		patch=0
+	fi
+	;;
+minor)
+	minor=$((minor + 1))
+	patch=0
+	;;
+patch)
+	patch=$((patch + 1))
+	;;
+esac
+
+next="${major}.${minor}.${patch}"
+tag="v${next}"
+echo "release: ${current} -> ${next} (${bump} bump)"
+
+if [ "${RELEASE_DRY_RUN:-}" = "1" ]; then
+	echo "release: dry run, stopping before tag/publish."
+	exit 0
+fi
+
+if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+	echo "release: tag ${tag} already exists; skipping."
+	exit 0
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git tag -a "${tag}" -m "${tag}"
+git push origin "${tag}"
+
+goreleaser release --clean

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,8 +76,11 @@ Obsidian iCloud vault. Single Go module.
 ## Commits & releases
 
 - [Conventional Commits](https://www.conventionalcommits.org) are required
-  (`convco`; PR CI runs `lint:commits`). go-semantic-release derives the version
-  from commit history on push to `main`, so commit type matters.
+  (`convco`; PR CI runs `lint:commits`). On push to `main`, `mise run release`
+  (`.mise/scripts/release.sh`) computes the next version from commit history
+  (`feat` → minor, `fix`/`perf` → patch, breaking → minor while 0.x), tags it,
+  and publishes binaries + notes with GoReleaser (`.goreleaser.yml`). So the
+  commit type drives the release — preview with `mise run release:dry`.
 - Commit signing (GPG) is enabled — prefer to let the human commit. If you must
   commit to validate, use a throwaway commit and `git reset --soft` afterward.
 

--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ in place), `lint:go:fix`, `mod:tidy`, `lint:commits` (convco), and `mise:lock`.
 Run `mise tasks` to list them all.
 
 Commits follow [Conventional Commits](https://www.conventionalcommits.org)
-(validated by `convco`); releases are cut from commit history by
-go-semantic-release on push to `main`.
+(validated by `convco`). On push to `main` the `release` workflow computes the
+next version from the commit history, tags it, and publishes the changelog and
+Go binaries with [GoReleaser](https://goreleaser.com) (`feat` → minor, `fix` /
+`perf` → patch). Preview the next version locally with `mise run release:dry`.
 
 Tool, Go-module, and GitHub-Actions updates are managed by Renovate, which opens
 a single grouped PR on the first Tuesday of each month. `mise.lock` is committed

--- a/mise.lock
+++ b/mise.lock
@@ -5,24 +5,24 @@ version = "0.6.4"
 backend = "github:convco/convco"
 
 [tools."github:convco/convco".options]
-asset_pattern = "convco-ubuntu.zip"
-
-[tools."github:convco/convco"."platforms.linux-x64"]
-checksum = "sha256:d6e43a1975949ef05d31bb1ac64fdd7c2dbc18b0b65df075c16dc296b8153be7"
-url = "https://github.com/convco/convco/releases/download/v0.6.4/convco-ubuntu.zip"
-url_api = "https://api.github.com/repos/convco/convco/releases/assets/428442682"
-
-[[tools."github:convco/convco"]]
-version = "0.6.4"
-backend = "github:convco/convco"
-
-[tools."github:convco/convco".options]
 asset_pattern = "convco-macos.zip"
 
 [tools."github:convco/convco"."platforms.macos-arm64"]
 checksum = "sha256:88901e63aa26b601b6726bff8e05cab89d16ebcb772f719bad431a40b12caa54"
 url = "https://github.com/convco/convco/releases/download/v0.6.4/convco-macos.zip"
 url_api = "https://api.github.com/repos/convco/convco/releases/assets/428442702"
+
+[[tools."github:convco/convco"]]
+version = "0.6.4"
+backend = "github:convco/convco"
+
+[tools."github:convco/convco".options]
+asset_pattern = "convco-ubuntu.zip"
+
+[tools."github:convco/convco"."platforms.linux-x64"]
+checksum = "sha256:d6e43a1975949ef05d31bb1ac64fdd7c2dbc18b0b65df075c16dc296b8153be7"
+url = "https://github.com/convco/convco/releases/download/v0.6.4/convco-ubuntu.zip"
+url_api = "https://api.github.com/repos/convco/convco/releases/assets/428442682"
 
 [[tools.go]]
 version = "1.26.4"
@@ -52,6 +52,20 @@ provenance = "github-attestations"
 [tools.golangci-lint."platforms.macos-arm64"]
 checksum = "sha256:a9c54498731b3128f79e090be6110f3e5fffccc617b08142ed244d4126c73f29"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-darwin-arm64.tar.gz"
+provenance = "github-attestations"
+
+[[tools.goreleaser]]
+version = "2.16.0"
+backend = "aqua:goreleaser/goreleaser"
+
+[tools.goreleaser."platforms.linux-x64"]
+checksum = "sha256:eaae05b5eba07533bd0f06846b68c808399504784df00c62eb219541fc04e5e2"
+url = "https://github.com/goreleaser/goreleaser/releases/download/v2.16.0/goreleaser_Linux_x86_64.tar.gz"
+provenance = "github-attestations"
+
+[tools.goreleaser."platforms.macos-arm64"]
+checksum = "sha256:6a102e4d588fd3553a9ac7321ca6023a9f205843f4861ca35bd337dfa9e72ece"
+url = "https://github.com/goreleaser/goreleaser/releases/download/v2.16.0/goreleaser_Darwin_all.tar.gz"
 provenance = "github-attestations"
 
 [[tools.rumdl]]

--- a/mise.toml
+++ b/mise.toml
@@ -17,14 +17,15 @@ golangci-lint = "2.12.2"
 rumdl = "0.2.23"
 shellcheck = "0.11.0"
 yamlfmt = "0.21.0"
+goreleaser = "2.16.0"
 # golines (Go long-line formatter) — pinned via the go: backend to match the
 # binary used elsewhere. Only used by the local `fmt:go` task.
 "go:github.com/segmentio/golines" = "0.13.0"
 
-# convco — Conventional Commits validator backing `lint:commits` (go-semantic-release
-# relies on conventional commits for versioning). No aqua registry entry yet, so
-# pin via the github backend with per-platform asset patterns. No Intel-macOS
-# asset is published, so macos-x64 is omitted.
+# convco — Conventional Commits validator. Backs the `lint:commits` task and the
+# `release` version bump. No aqua registry entry yet, so pin via the github
+# backend with per-platform asset patterns. No Intel-macOS asset is published,
+# so macos-x64 is omitted.
 [tools."github:convco/convco"]
 version = "0.6.4"
 
@@ -150,4 +151,23 @@ depends = [
   "lint:go",
   "build",
   "test",
+  "release:check",
 ]
+
+# ────────────────────────────────────────────────────────────────────────────
+# Release — compute the next version from Conventional Commits, tag it, and
+# publish binaries + notes with GoReleaser. Driven on push to main by
+# .github/workflows/release.yml. Needs GITHUB_TOKEN to publish.
+# ────────────────────────────────────────────────────────────────────────────
+
+[tasks.release]
+description = "Cut a release: bump version from commits, tag, and publish via GoReleaser"
+run = "bash ./.mise/scripts/release.sh"
+
+[tasks."release:dry"]
+description = "Print the version the next release would cut, without tagging or publishing"
+run = "RELEASE_DRY_RUN=1 bash ./.mise/scripts/release.sh"
+
+[tasks."release:check"]
+description = "Validate the GoReleaser config (CI-safe)"
+run = "goreleaser check"


### PR DESCRIPTION
Removed the go-semantic-release GitHub Action and replaced it with a local
`mise run release` script that computes versions from Conventional Commits and
publishes via GoReleaser. Versioning behavior unchanged: feat → minor,
fix/perf → patch, breaking → minor while 0.x. Added `release:dry` task.
